### PR TITLE
add caps for cl_intel_unified_shared_memory

### DIFF
--- a/deviceinfo.cpp
+++ b/deviceinfo.cpp
@@ -353,6 +353,13 @@ void DeviceInfo::readDeviceInfoValue(DeviceInfoValueDescriptor descriptor, QStri
 		deviceInfo.push_back(infoValue);
 		break;
 	}
+	case clValueType::cl_device_unified_shared_memory_capabilities_intel:
+	{
+		cl_device_unified_shared_memory_capabilities_intel value;
+        _clGetDeviceInfo(this->deviceId, descriptor.name, sizeof(cl_device_unified_shared_memory_capabilities_intel), &value, nullptr);
+        deviceInfo.push_back(DeviceInfoValue(descriptor.name, QVariant::fromValue(value), extension, descriptor.displayFunction));
+		break;
+	}
 	/* Special cases */
 	case clValueType::special:
 	{
@@ -847,6 +854,18 @@ void DeviceInfo::readExtensionInfo()
 		};
 		for (auto info : infoList) {
 			readDeviceInfoValue(info, "cl_intel_command_queue_families");
+		}
+	}
+	if (extensionSupported("cl_intel_unified_shared_memory")) {
+		std::vector<DeviceInfoValueDescriptor> infoList = {
+			{ CL_DEVICE_HOST_MEM_CAPABILITIES_INTEL, clValueType::cl_device_unified_shared_memory_capabilities_intel, utils::displayDeviceUsmCapabilitiesIntel },
+			{ CL_DEVICE_DEVICE_MEM_CAPABILITIES_INTEL, clValueType::cl_device_unified_shared_memory_capabilities_intel, utils::displayDeviceUsmCapabilitiesIntel },
+			{ CL_DEVICE_SINGLE_DEVICE_SHARED_MEM_CAPABILITIES_INTEL, clValueType::cl_device_unified_shared_memory_capabilities_intel, utils::displayDeviceUsmCapabilitiesIntel },
+			{ CL_DEVICE_CROSS_DEVICE_SHARED_MEM_CAPABILITIES_INTEL, clValueType::cl_device_unified_shared_memory_capabilities_intel, utils::displayDeviceUsmCapabilitiesIntel },
+			{ CL_DEVICE_SHARED_SYSTEM_MEM_CAPABILITIES_INTEL, clValueType::cl_device_unified_shared_memory_capabilities_intel, utils::displayDeviceUsmCapabilitiesIntel },
+		};
+		for (auto info : infoList) {
+			readDeviceInfoValue(info, "cl_intel_unified_shared_memory");
 		}
 	}
 

--- a/displayutils.cpp
+++ b/displayutils.cpp
@@ -288,6 +288,17 @@ namespace utils
         }
     }
 
+    QString displayDeviceUsmCapabilitiesIntel(QVariant value)
+    {
+        std::unordered_map<uint32_t, QString> flags = {
+            { CL_UNIFIED_SHARED_MEMORY_ACCESS_INTEL, "USM_ACCESS"},
+            { CL_UNIFIED_SHARED_MEMORY_ATOMIC_ACCESS_INTEL, "USM_ATOMIC_ACCESS" },
+            { CL_UNIFIED_SHARED_MEMORY_CONCURRENT_ACCESS_INTEL, "USM_CONCURRENT_ACCESS" },
+            { CL_UNIFIED_SHARED_MEMORY_CONCURRENT_ATOMIC_ACCESS_INTEL, "USM_CONCURRENT_ATOMIC_ACCESS" }
+        };
+        return displayFlags(value.toInt(), flags);
+    }
+
     QString displayDetailValueArraySize(QVariant value)
     {
         return QString("[%1]").arg(value.toInt());

--- a/displayutils.h
+++ b/displayutils.h
@@ -54,6 +54,7 @@ namespace utils
 	QString displaySchedulingControlsCapabilitiesARM(QVariant value);
 	QString displayQueueFamilyPropertiesIntel(QVariant value);
 	QString displayCommandQueueCapabilitiesIntel(QVariant value);
+	QString displayDeviceUsmCapabilitiesIntel(QVariant value);
 	QString displayDetailValueArraySize(QVariant value);
 	QString displayItegerDotProductCapabilities(QVariant value);
 	QString displayExternalMemoryHandleTypes(QVariant value);

--- a/openclutils.h
+++ b/openclutils.h
@@ -59,6 +59,7 @@ enum class clValueType {
 	cl_external_memory_handle_type_khr_array,
 	cl_external_semaphore_handle_type_khr,
 	cl_device_command_buffer_capabilities_khr,
+	cl_device_unified_shared_memory_capabilities_intel,
 	special
 };
 


### PR DESCRIPTION
Adds supported capabilities for the different types of USM when the cl_intel_unified_shared_memory extension is supported.

See:
https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_unified_shared_memory.html

Tested on a recent Intel integrated GPU (Intel(R) UHD Graphics 770 [0x4680]), though this extension should be supported on most Intel devices.